### PR TITLE
JsonObject properties are now ordered correctly using LinkedHashMap.

### DIFF
--- a/sdk/core/azure-json/src/main/java/com/azure/json/JsonObject.java
+++ b/sdk/core/azure-json/src/main/java/com/azure/json/JsonObject.java
@@ -1,9 +1,9 @@
 package com.azure.json;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 
 /**
  * Class representing the JSON object type.
@@ -13,12 +13,10 @@ public class JsonObject extends JsonElement {
      * Stores the key and values of each property in the JsonObject. The values
      * may be any valid JSON type: object, array, string, number, boolean, and null
      */
-    private Map<String, JsonElement> properties = new HashMap<>();
+    private Map<String, JsonElement> properties = new LinkedHashMap<>();
 
     /**
      * Adds a new property into the JsonObject object.
-     * TODO: need code changes to make the properties stored in the order they
-     * are added
      *
      * @param key specifies the key of the property being added
      * @param element specifies the value of the property being added

--- a/sdk/core/azure-json/src/main/java/com/azure/json/MainClass.java
+++ b/sdk/core/azure-json/src/main/java/com/azure/json/MainClass.java
@@ -1,5 +1,5 @@
 package com.azure.json;
-
+import com.azure.json.InvalidJsonDataTypeException; 
 
 /**
  * This class acts purely as a playground for testing and playing around with
@@ -37,6 +37,17 @@ public class MainClass {
                 .addElement(new JsonObject().addProperty("Value3", true).addProperty("Value4", null))
                 .toJson();
         System.out.println(arrayTest);
+
+        
+        // Testing that LinkedHashMap is working as expected 
+        JsonObject testingPropertyOrder = new JsonObject(); 
+        for(int i = 0; i < 10; i++) { 
+            testingPropertyOrder.addProperty(
+                "Property"+Integer.toString(i), 
+                "value"+Integer.toString(i)
+            );
+        }
+        System.out.println(testingPropertyOrder);
 
         /*
 

--- a/sdk/core/azure-json/src/test/java/com/azure/json/JsonTesting.java
+++ b/sdk/core/azure-json/src/test/java/com/azure/json/JsonTesting.java
@@ -1,6 +1,6 @@
 package com.azure.json;
 
-import com.sun.jdi.InvalidTypeException;
+import com.azure.json.InvalidJsonDataTypeException; 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -210,7 +210,7 @@ public class JsonTesting {
 
     //Section 4: Modify existing Entries
     @Test
-    public void objectSetProperty() throws InvalidTypeException {
+    public void objectSetProperty() throws InvalidJsonDataTypeException {
         JsonElement test = new JsonObject().addProperty("First", "Keyword");
         test.asObject().setProperty("First", "Replaced");
         assertEquals("\"Replaced\"", test.asObject().getProperty("First").toString());


### PR DESCRIPTION
# Description

JsonObject properties are now ordered correctly using LinkedHashMap. 

I have replaced InvalidTypeExceptions with InvalidJsonDataTypeException.

